### PR TITLE
Update hashlocal & clhashlookup services for rejected extension handling

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -37,9 +37,9 @@ resp_mode=true
 shadow_service=false
 preview_bytes = "1024" #byte
 preview_enabled = true# options send preview header or not
-process_extensions = ["pdf", "zip", "com"] # * = everything except the ones in bypass, unknown = system couldn't find out the type of the file
-reject_extensions = ["docx"]
 bypass_extensions = ["*"]
+process_extensions = ["zip","exe","com"]# * = everything except the ones in bypass, unknown = system couldn't find out the type of>
+reject_extensions = ["pdf"] 
 #max file size value from 1 to 9223372036854775807, and value of zero means unlimited
 max_filesize = 0 #bytes
 return_original_if_max_file_size_exceeded=false
@@ -56,8 +56,8 @@ shadow_service=false
 preview_bytes = "1024" #byte
 preview_enabled = true# options send preview header or not
 bypass_extensions = ["*"]
-process_extensions = ["pdf","exe", "zip"] # * = everything except the ones in bypass, unknown = system couldn't find out the type of the file
-reject_extensions = ["docx"]
+process_extensions = ["zip","exe","com"]# * = everything except the ones in bypass, unknown = system couldn't find out the type of>
+reject_extensions = ["pdf"] 
 scan_url = "https://hashlookup.circl.lu/lookup/sha256/" #
 timeout  = 300 #seconds , ICAP will return 408 - Request timeout
 fail_threshold = 2
@@ -77,11 +77,11 @@ service_tag = "hashlocal ICAP"  #ISTAG
 req_mode=true
 resp_mode=true
 shadow_service=false
-preview_bytes = "1024" #byte
-preview_enabled = true# options send preview header or not
+preview_bytes = "0" #byte
+preview_enabled = true# options send preview hea der or not  
 bypass_extensions = ["*"]
-process_extensions = ["pdf","exe", "zip"] # * = everything except the ones in bypass, unknown = system couldn't find out the type of the file
-reject_extensions = ["docx"]
+process_extensions = ["zip","exe","com"]# * = everything except the ones in bypass, unknown = system couldn't find out the type of>
+reject_extensions = ["pdf"] 
 hash_file = "./hash_file/hash_file_path.txt" #
 max_filesize = 0 #bytes
 return_original_if_max_file_size_exceeded=true
@@ -99,8 +99,8 @@ resp_mode=true
 shadow_service=false
 preview_bytes = "1024" #byte
 preview_enabled = true# options send preview header or not
-process_extensions = ["pdf", "zip", "com"] # * = everything except the ones in bypass, unknown = system couldn't find out the type of the file
-reject_extensions = ["docx"]
+process_extensions = ["zip","exe","com"]# * = everything except the ones in bypass, unknown = system couldn't find out the type of>
+reject_extensions = ["pdf"] 
 bypass_extensions = ["*"]
 socket_path = "/var/run/clamav/clamd.ctl"
 fail_threshold = 2

--- a/config.toml
+++ b/config.toml
@@ -38,8 +38,8 @@ shadow_service=false
 preview_bytes = "1024" #byte
 preview_enabled = true# options send preview header or not
 bypass_extensions = ["*"]
-process_extensions = ["zip","exe","com"]# * = everything except the ones in bypass, unknown = system couldn't find out the type of>
-reject_extensions = ["pdf"] 
+process_extensions = ["zip","exe","com","txt"]# * = everything except the ones in bypass, unknown = system couldn't find out the type of>
+reject_extensions = ["docx","pdf"] 
 #max file size value from 1 to 9223372036854775807, and value of zero means unlimited
 max_filesize = 0 #bytes
 return_original_if_max_file_size_exceeded=false
@@ -56,8 +56,8 @@ shadow_service=false
 preview_bytes = "1024" #byte
 preview_enabled = true# options send preview header or not
 bypass_extensions = ["*"]
-process_extensions = ["zip","exe","com"]# * = everything except the ones in bypass, unknown = system couldn't find out the type of>
-reject_extensions = ["pdf"] 
+process_extensions = ["zip","exe","com","txt"]# * = everything except the ones in bypass, unknown = system couldn't find out the type of>
+reject_extensions = ["docx","pdf"]  
 scan_url = "https://hashlookup.circl.lu/lookup/sha256/" #
 timeout  = 300 #seconds , ICAP will return 408 - Request timeout
 fail_threshold = 2
@@ -80,8 +80,8 @@ shadow_service=false
 preview_bytes = "0" #byte
 preview_enabled = true# options send preview hea der or not  
 bypass_extensions = ["*"]
-process_extensions = ["zip","exe","com"]# * = everything except the ones in bypass, unknown = system couldn't find out the type of>
-reject_extensions = ["pdf"] 
+process_extensions = ["zip","exe","com","txt"]# * = everything except the ones in bypass, unknown = system couldn't find out the type of>
+reject_extensions = ["docx","pdf"] 
 hash_file = "./hash_file/hash_file_path.txt" #
 max_filesize = 0 #bytes
 return_original_if_max_file_size_exceeded=true
@@ -99,8 +99,8 @@ resp_mode=true
 shadow_service=false
 preview_bytes = "1024" #byte
 preview_enabled = true# options send preview header or not
-process_extensions = ["zip","exe","com"]# * = everything except the ones in bypass, unknown = system couldn't find out the type of>
-reject_extensions = ["pdf"] 
+process_extensions = ["zip","exe","com","txt"]# * = everything except the ones in bypass, unknown = system couldn't find out the type of>
+reject_extensions = ["docx","pdf"] 
 bypass_extensions = ["*"]
 socket_path = "/var/run/clamav/clamd.ctl"
 fail_threshold = 2

--- a/config.toml
+++ b/config.toml
@@ -38,7 +38,7 @@ shadow_service=false
 preview_bytes = "1024" #byte
 preview_enabled = true# options send preview header or not
 bypass_extensions = ["*"]
-process_extensions = ["zip","exe","com","txt"]# * = everything except the ones in bypass, unknown = system couldn't find out the type of>
+process_extensions = ["zip","exe","com"]# * = everything except the ones in bypass, unknown = system couldn't find out the type of>
 reject_extensions = ["docx","pdf"] 
 #max file size value from 1 to 9223372036854775807, and value of zero means unlimited
 max_filesize = 0 #bytes
@@ -56,7 +56,7 @@ shadow_service=false
 preview_bytes = "1024" #byte
 preview_enabled = true# options send preview header or not
 bypass_extensions = ["*"]
-process_extensions = ["zip","exe","com","txt"]# * = everything except the ones in bypass, unknown = system couldn't find out the type of>
+process_extensions = ["zip","exe","com"]# * = everything except the ones in bypass, unknown = system couldn't find out the type of>
 reject_extensions = ["docx","pdf"]  
 scan_url = "https://hashlookup.circl.lu/lookup/sha256/" #
 timeout  = 300 #seconds , ICAP will return 408 - Request timeout
@@ -77,10 +77,10 @@ service_tag = "hashlocal ICAP"  #ISTAG
 req_mode=true
 resp_mode=true
 shadow_service=false
-preview_bytes = "0" #byte
+preview_bytes = "1024" #byte
 preview_enabled = true# options send preview hea der or not  
 bypass_extensions = ["*"]
-process_extensions = ["zip","exe","com","txt"]# * = everything except the ones in bypass, unknown = system couldn't find out the type of>
+process_extensions = ["zip","exe","com"]# * = everything except the ones in bypass, unknown = system couldn't find out the type of>
 reject_extensions = ["docx","pdf"] 
 hash_file = "./hash_file/hash_file_path.txt" #
 max_filesize = 0 #bytes
@@ -99,7 +99,7 @@ resp_mode=true
 shadow_service=false
 preview_bytes = "1024" #byte
 preview_enabled = true# options send preview header or not
-process_extensions = ["zip","exe","com","txt"]# * = everything except the ones in bypass, unknown = system couldn't find out the type of>
+process_extensions = ["zip","exe","com"]# * = everything except the ones in bypass, unknown = system couldn't find out the type of>
 reject_extensions = ["docx","pdf"] 
 bypass_extensions = ["*"]
 socket_path = "/var/run/clamav/clamd.ctl"

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/dutchcoders/go-clamd v0.0.0-20170520113014-b970184f4d9e
 	github.com/google/uuid v1.1.2
-	github.com/h2non/filetype v1.0.12
+	github.com/h2non/filetype v1.1.3
 	github.com/spf13/viper v1.9.0
 	github.com/xhit/go-str2duration/v2 v2.0.0
 	go.uber.org/zap v1.22.0

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,8 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gax-go/v2 v2.1.0/go.mod h1:Q3nei7sK6ybPYH7twZdmQpAd1MKb7pfu6SK+H1/DsU0=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
-github.com/h2non/filetype v1.0.12 h1:yHCsIe0y2cvbDARtJhGBTD2ecvqMSTvlIcph9En/Zao=
-github.com/h2non/filetype v1.0.12/go.mod h1:319b3zT68BvV+WRj7cwy856M2ehB3HqNOt6sy1HndBY=
+github.com/h2non/filetype v1.1.3 h1:FKkx9QbD7HR/zjK1Ia5XiBsq9zdLi5Kf3zGyFTAFkGg=
+github.com/h2non/filetype v1.1.3/go.mod h1:319b3zT68BvV+WRj7cwy856M2ehB3HqNOt6sy1HndBY=
 github.com/hashicorp/consul/api v1.10.1/go.mod h1:XjsvQN+RJGWI2TWy1/kqaE16HrR2J/FWgkYjdZQsX9M=
 github.com/hashicorp/consul/sdk v0.8.0/go.mod h1:GBvyrGALthsZObzUGsfgHZQDXjg4lOjagTIwIR1vPms=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/service/services-utilities/general-functions/general-functions.go
+++ b/service/services-utilities/general-functions/general-functions.go
@@ -495,7 +495,7 @@ func (f *GeneralFunc) InitSecure(VerifyServerCert bool) bool {
 }
 
 // GetMimeExtension returns the mime type extension of the data
-func (f *GeneralFunc) GetMimeExtension(data []byte, contentType string, filename string, file []byte) string {
+func (f *GeneralFunc) GetMimeExtension(data []byte, contentType string, filename string, allfile bool) string {
 	filename = strings.ToLower(filename)
 
 	logging.Logger.Info(utils.PrepareLogMsg(f.xICAPMetadata,
@@ -519,18 +519,18 @@ func (f *GeneralFunc) GetMimeExtension(data []byte, contentType string, filename
 		"application/vnd.openxmlformats-officedocument.presentationml.presentation": "pptx",
 	}
 
-	contentType = strings.Split(contentType, ";")[0]
-
-	// Handle .docx/.xlsx/.pptx disguised as zip
-	if (kind == filetype.Unknown || kind.Extension == "zip") && file != nil && len(file) > 0 {
-
-		kind, _ = filetype.Match(file)
-
+	if allfile {
 		logging.Logger.Debug(utils.PrepareLogMsg(f.xICAPMetadata,
 			"HTTP message body mime extension (from all file bytes) is "+kind.Extension))
-		if kind != filetype.Unknown {
-			return kind.Extension
-		}
+	}
+
+	contentType = strings.Split(contentType, ";")[0]
+	filenameArr := strings.Split(filename, ".")
+
+	// Handle .docx/.xlsx/.pptx disguised as zip or .doc as ppt .
+	if kind.Extension == "zip" && !allfile {
+		return "zip-partial"
+
 	}
 
 	if kind == filetype.Unknown {
@@ -540,7 +540,6 @@ func (f *GeneralFunc) GetMimeExtension(data []byte, contentType string, filename
 			return ext
 		}
 
-		filenameArr := strings.Split(filename, ".")
 		if len(filenameArr) > 1 {
 			logging.Logger.Debug(utils.PrepareLogMsg(f.xICAPMetadata,
 				"HTTP message body mime extension (from filename) is "+filenameArr[len(filenameArr)-1]))
@@ -551,9 +550,11 @@ func (f *GeneralFunc) GetMimeExtension(data []byte, contentType string, filename
 			"HTTP message body mime extension is unknown"))
 		return utils.Unknown
 	}
+	if !allfile {
+		logging.Logger.Debug(utils.PrepareLogMsg(f.xICAPMetadata,
+			"HTTP message body mime extension (from the first 262 bytes) is "+kind.Extension))
+	}
 
-	logging.Logger.Debug(utils.PrepareLogMsg(f.xICAPMetadata,
-		"HTTP message body mime extension (from the first 262 bytes) is "+kind.Extension))
 	return kind.Extension
 }
 

--- a/service/services-utilities/general-functions/general-functions.go
+++ b/service/services-utilities/general-functions/general-functions.go
@@ -308,10 +308,14 @@ func (f *GeneralFunc) GetFileName(serviceName string, xICAPMetadata string) stri
 
 	} else {
 		logging.Logger.Info(utils.PrepareLogMsg(xICAPMetadata, serviceName+" file name  get form httpMsg return unnamed_file  : "+filename))
-
-		return "unnamed_file"
 	}
 
+	if filename == "" || filename == "/" || filename == "." || filename == ".." {
+		if f.httpMsg.Response.Header.Get("X-C-Icap-Client-Original-File") != "" {
+			filename = f.httpMsg.Response.Header.Get("X-C-Icap-Client-Original-File")
+			logging.Logger.Info(utils.PrepareLogMsg(xICAPMetadata, serviceName+" file name  get form X-C-Icap-Client-Original-File  : "+filename))
+		}
+	}
 	if len(filename) < 2 {
 		return "unnamed_file"
 	}

--- a/service/services-utilities/general-functions/general-functions.go
+++ b/service/services-utilities/general-functions/general-functions.go
@@ -61,12 +61,10 @@ func (f *GeneralFunc) CopyingFileToTheBuffer(methodName string) ([]byte, Content
 	switch methodName {
 	case utils.ICAPModeReq:
 		file, reqContentType, err = f.copyingFileToTheBufferReq()
-		break
 	case utils.ICAPModeResp:
-		// file, err = f.copyingFileToTheBufferResp()
-		// no need we will get file form storgeclient
-
-		break
+		file, err = f.copyingFileToTheBufferResp()
+	default:
+		logging.Logger.Error(utils.PrepareLogMsg(f.xICAPMetadata, "unknown method name: "+methodName))
 	}
 	if err != nil {
 		return nil, nil, err
@@ -497,36 +495,66 @@ func (f *GeneralFunc) InitSecure(VerifyServerCert bool) bool {
 }
 
 // GetMimeExtension returns the mime type extension of the data
-func (f *GeneralFunc) GetMimeExtension(data []byte, contentType string, filename string) string {
+func (f *GeneralFunc) GetMimeExtension(data []byte, contentType string, filename string, file []byte) string {
 	filename = strings.ToLower(filename)
+
 	logging.Logger.Info(utils.PrepareLogMsg(f.xICAPMetadata,
 		"getting the mime extension of the HTTP message body"))
+
 	kind, _ := filetype.Match(data)
-	exts := map[string]string{"application/xml": "xml", "application/html": "html", "text/html": "html", "text/json": "html", "application/json": "json", "text/plain": "txt"}
+
+	exts := map[string]string{
+
+		"application/xml":    "xml",
+		"application/html":   "html",
+		"text/html":          "html",
+		"text/json":          "html",
+		"application/json":   "json",
+		"text/plain":         "txt",
+		"application/msword": "doc",
+		"application/vnd.openxmlformats-officedocument.wordprocessingml.document": "docx",
+		"application/vnd.ms-excel": "xls",
+		"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":         "xlsx",
+		"application/vnd.ms-powerpoint":                                             "ppt",
+		"application/vnd.openxmlformats-officedocument.presentationml.presentation": "pptx",
+	}
+
 	contentType = strings.Split(contentType, ";")[0]
-	if kind == filetype.Unknown {
-		if _, ok := exts[contentType]; ok {
-			logging.Logger.Debug(utils.PrepareLogMsg(f.xICAPMetadata,
-				"HTTP message body mime extension is "+kind.Extension))
-			return exts[contentType]
+
+	// Handle .docx/.xlsx/.pptx disguised as zip
+	if (kind == filetype.Unknown || kind.Extension == "zip") && file != nil && len(file) > 0 {
+
+		kind, _ = filetype.Match(file)
+
+		logging.Logger.Debug(utils.PrepareLogMsg(f.xICAPMetadata,
+			"HTTP message body mime extension (from all file bytes) is "+kind.Extension))
+		if kind != filetype.Unknown {
+			return kind.Extension
 		}
 	}
 
 	if kind == filetype.Unknown {
+		if ext, ok := exts[contentType]; ok {
+			logging.Logger.Debug(utils.PrepareLogMsg(f.xICAPMetadata,
+				"HTTP message body mime extension (from contentType) is "+ext))
+			return ext
+		}
+
 		filenameArr := strings.Split(filename, ".")
 		if len(filenameArr) > 1 {
+			logging.Logger.Debug(utils.PrepareLogMsg(f.xICAPMetadata,
+				"HTTP message body mime extension (from filename) is "+filenameArr[len(filenameArr)-1]))
 			return filenameArr[len(filenameArr)-1]
 		}
-	}
-	if kind == filetype.Unknown {
+
 		logging.Logger.Debug(utils.PrepareLogMsg(f.xICAPMetadata,
-			"HTTP message body mime extension is "+kind.Extension))
+			"HTTP message body mime extension is unknown"))
 		return utils.Unknown
 	}
-	logging.Logger.Debug(utils.PrepareLogMsg(f.xICAPMetadata,
-		"HTTP message body mime extension is "+kind.Extension))
-	return kind.Extension
 
+	logging.Logger.Debug(utils.PrepareLogMsg(f.xICAPMetadata,
+		"HTTP message body mime extension (from the first 262 bytes) is "+kind.Extension))
+	return kind.Extension
 }
 
 func (f *GeneralFunc) LogHTTPMsgHeaders(methodName string) map[string]interface{} {

--- a/service/services/clamav/clamav.go
+++ b/service/services/clamav/clamav.go
@@ -84,7 +84,7 @@ func (c *Clamav) Processing(partial bool, IcapHeader textproto.MIMEHeader) (int,
 
 	logging.Logger.Info(utils.PrepareLogMsg(c.xICAPMetadata, c.serviceName+" file name : "+fileName))
 
-	fileExtension := c.generalFunc.GetMimeExtension(file, contentType[0], fileName)
+	fileExtension := c.generalFunc.GetMimeExtension(nil, contentType[0], fileName, file)
 
 	//check if the file extension is a bypass extension
 	//if yes we will not modify the file, and we will return 204 No modifications

--- a/service/services/clamav/clamav.go
+++ b/service/services/clamav/clamav.go
@@ -84,7 +84,7 @@ func (c *Clamav) Processing(partial bool, IcapHeader textproto.MIMEHeader) (int,
 
 	logging.Logger.Info(utils.PrepareLogMsg(c.xICAPMetadata, c.serviceName+" file name : "+fileName))
 
-	fileExtension := c.generalFunc.GetMimeExtension(nil, contentType[0], fileName, file)
+	fileExtension := c.generalFunc.GetMimeExtension(file, contentType[0], fileName, true)
 
 	//check if the file extension is a bypass extension
 	//if yes we will not modify the file, and we will return 204 No modifications

--- a/service/services/clhashlookup/clhashlookup.go
+++ b/service/services/clhashlookup/clhashlookup.go
@@ -49,12 +49,14 @@ func (d *Hashlookup) Processing(partial bool, IcapHeader textproto.MIMEHeader) (
 		fileExtension = filepath.Ext(fileName)[1:]
 	} else {
 		// Determine the file extension using the header data
-		fileExtension = d.generalFunc.GetMimeExtension(filehead, contentType[0], fileName)
+		fileExtension = d.generalFunc.GetMimeExtension(filehead, contentType[0], fileName, file)
 	}
+
 	d.FileHash, err = d.calculateFileHash(file)
 	if err != nil {
 		logging.Logger.Error(utils.PrepareLogMsg(d.xICAPMetadata, d.serviceName+" calculateFileHash error : "+err.Error()))
 	}
+
 	/////////////////////////////////
 	isProcess, StatusCodeStr, _ := d.generalFunc.CheckTheExtension(fileExtension, d.extArrs,
 		d.processExts, d.rejectExts, d.bypassExts, d.return400IfFileExtRejected, d.isGzip(),

--- a/service/services/clhashlookup/clhashlookup.go
+++ b/service/services/clhashlookup/clhashlookup.go
@@ -49,7 +49,11 @@ func (d *Hashlookup) Processing(partial bool, IcapHeader textproto.MIMEHeader) (
 		fileExtension = filepath.Ext(fileName)[1:]
 	} else {
 		// Determine the file extension using the header data
-		fileExtension = d.generalFunc.GetMimeExtension(filehead, contentType[0], fileName, file)
+		fileExtension = d.generalFunc.GetMimeExtension(filehead, contentType[0], fileName, false)
+		// If the file extension is "zip-partial", we need to send all file to handle .docx disguised as zip
+		if fileExtension == "zip-partial" {
+			fileExtension = d.generalFunc.GetMimeExtension(file, contentType[0], fileName, true)
+		}
 	}
 
 	d.FileHash, err = d.calculateFileHash(file)

--- a/service/services/clhashlookup/clhashlookup.go
+++ b/service/services/clhashlookup/clhashlookup.go
@@ -56,7 +56,7 @@ func (d *Hashlookup) Processing(partial bool, IcapHeader textproto.MIMEHeader) (
 		logging.Logger.Error(utils.PrepareLogMsg(d.xICAPMetadata, d.serviceName+" calculateFileHash error : "+err.Error()))
 	}
 	/////////////////////////////////
-	isProcess, _, _ := d.generalFunc.CheckTheExtension(fileExtension, d.extArrs,
+	isProcess, StatusCodeStr, _ := d.generalFunc.CheckTheExtension(fileExtension, d.extArrs,
 		d.processExts, d.rejectExts, d.bypassExts, d.return400IfFileExtRejected, d.isGzip(),
 		d.serviceName, d.methodName, d.FileHash, d.httpMsg.Request.RequestURI, reqContentType, bytes.NewBuffer(file), ExceptionPagePath, fmt.Sprint(fileSize))
 
@@ -78,7 +78,7 @@ func (d *Hashlookup) Processing(partial bool, IcapHeader textproto.MIMEHeader) (
 	if isMal {
 		return d.handleMaliciousFile(fileSize)
 	}
-	return d.handleSuccessfulScan(file, fileSize, reqContentType)
+	return d.handleSuccessfulScan(StatusCodeStr, file, fileSize, reqContentType)
 }
 
 func (d *Hashlookup) initProcessing(IcapHeader textproto.MIMEHeader) {
@@ -194,7 +194,7 @@ func (d *Hashlookup) handleMaliciousFile(fileSize int) (int, interface{}, map[st
 	}
 }
 
-func (d *Hashlookup) handleSuccessfulScan(scannedFile []byte, fileSize int, reqContentType ContentTypes.ContentType) (int, interface{}, map[string]string, map[string]interface{}, map[string]interface{}, map[string]interface{}) {
+func (d *Hashlookup) handleSuccessfulScan(StatusCodeStr int, scannedFile []byte, fileSize int, reqContentType ContentTypes.ContentType) (int, interface{}, map[string]string, map[string]interface{}, map[string]interface{}, map[string]interface{}) {
 	// Log headers and processing stop
 	d.generalFunc.LogHTTPMsgHeaders(d.methodName)
 	logging.Logger.Info(utils.PrepareLogMsg(d.xICAPMetadata, d.serviceName+" service has stopped processing"))
@@ -203,7 +203,12 @@ func (d *Hashlookup) handleSuccessfulScan(scannedFile []byte, fileSize int, reqC
 	// Process the scanned file
 	scannedFile = d.generalFunc.PreparingFileAfterScanning(scannedFile, reqContentType, d.methodName)
 
-	return utils.NoModificationStatusCodeStr, d.generalFunc.ReturningHttpMessageWithFile(d.methodName, scannedFile),
+	// The file was processed successfully with no changes
+	if StatusCodeStr == 0 {
+		StatusCodeStr = utils.NoModificationStatusCodeStr
+	}
+
+	return StatusCodeStr, d.generalFunc.ReturningHttpMessageWithFile(d.methodName, scannedFile),
 		d.serviceHeaders, d.msgHeadersBeforeProcessing, d.msgHeadersAfterProcessing, d.vendorMsgs
 }
 
@@ -267,7 +272,7 @@ func (d *Hashlookup) calculateFileHash(file []byte) (string, error) {
 func mapToString(m map[string]string) string {
 	var sb strings.Builder
 	for key, value := range m {
-		sb.WriteString(fmt.Sprintf("\r\n"))
+		sb.WriteString("\r\n")
 		sb.WriteString(fmt.Sprintf("%s: %s", key, value))
 	}
 	return sb.String()

--- a/service/services/echo/echo.go
+++ b/service/services/echo/echo.go
@@ -62,7 +62,7 @@ func (e *Echo) Processing(partial bool, IcapHeader textproto.MIMEHeader) (int, i
 	if len(contentType) == 0 {
 		contentType = append(contentType, "")
 	}
-	fileExtension := e.generalFunc.GetMimeExtension(file, contentType[0], fileName)
+	fileExtension := e.generalFunc.GetMimeExtension(nil, contentType[0], fileName, file)
 	fileSize := fmt.Sprintf("%v kb", len(file)/1000)
 
 	//check if the file extension is a bypass extension

--- a/service/services/echo/echo.go
+++ b/service/services/echo/echo.go
@@ -62,7 +62,7 @@ func (e *Echo) Processing(partial bool, IcapHeader textproto.MIMEHeader) (int, i
 	if len(contentType) == 0 {
 		contentType = append(contentType, "")
 	}
-	fileExtension := e.generalFunc.GetMimeExtension(nil, contentType[0], fileName, file)
+	fileExtension := e.generalFunc.GetMimeExtension(file, contentType[0], fileName, true)
 	fileSize := fmt.Sprintf("%v kb", len(file)/1000)
 
 	//check if the file extension is a bypass extension

--- a/service/services/hashlocal/hashlocal.go
+++ b/service/services/hashlocal/hashlocal.go
@@ -51,7 +51,11 @@ func (h *Hashlocal) Processing(partial bool, IcapHeader textproto.MIMEHeader) (i
 		fileExtension = filepath.Ext(fileName)[1:]
 	} else {
 		// Determine the file extension using the header data
-		fileExtension = h.generalFunc.GetMimeExtension(filehead, contentType[0], fileName, file)
+		fileExtension = h.generalFunc.GetMimeExtension(filehead, contentType[0], fileName, false)
+		// If the file extension is "zip-partial", we need to send all file to handle .docx disguised as zip
+		if fileExtension == "zip-partial" {
+			fileExtension = h.generalFunc.GetMimeExtension(file, contentType[0], fileName, true)
+		}
 	}
 	h.FileHash, err = h.calculateFileHash(file)
 	if err != nil {

--- a/service/services/hashlocal/hashlocal.go
+++ b/service/services/hashlocal/hashlocal.go
@@ -51,7 +51,7 @@ func (h *Hashlocal) Processing(partial bool, IcapHeader textproto.MIMEHeader) (i
 		fileExtension = filepath.Ext(fileName)[1:]
 	} else {
 		// Determine the file extension using the header data
-		fileExtension = h.generalFunc.GetMimeExtension(filehead, contentType[0], fileName)
+		fileExtension = h.generalFunc.GetMimeExtension(filehead, contentType[0], fileName, file)
 	}
 	h.FileHash, err = h.calculateFileHash(file)
 	if err != nil {
@@ -137,6 +137,10 @@ func (h *Hashlocal) getFileNameAndContentType() (string, []string) {
 		fileName += utils.Unknown
 	}
 	logging.Logger.Info(utils.PrepareLogMsg(h.xICAPMetadata, h.serviceName+" file name : "+fileName))
+	if h.httpMsg.Response != nil {
+		logging.Logger.Info(utils.PrepareLogMsg(h.xICAPMetadata,
+			h.serviceName+" full response headers: "+fmt.Sprintf("%v", h.httpMsg.Response.Header)))
+	}
 	return fileName, contentType
 }
 

--- a/service/services/hashlocal/hashlocal.go
+++ b/service/services/hashlocal/hashlocal.go
@@ -58,10 +58,9 @@ func (h *Hashlocal) Processing(partial bool, IcapHeader textproto.MIMEHeader) (i
 		logging.Logger.Error(utils.PrepareLogMsg(h.xICAPMetadata, h.serviceName+" calculateFileHash error : "+err.Error()))
 	}
 	/////////////////////////////////
-	isProcess, _, _ := h.generalFunc.CheckTheExtension(fileExtension, h.extArrs,
+	isProcess, StatusCodeStr, _ := h.generalFunc.CheckTheExtension(fileExtension, h.extArrs,
 		h.processExts, h.rejectExts, h.bypassExts, h.return400IfFileExtRejected, h.isGzip(),
 		h.serviceName, h.methodName, h.FileHash, h.httpMsg.Request.RequestURI, reqContentType, bytes.NewBuffer(file), ExceptionPagePath, fmt.Sprint(fileSize))
-
 
 	///////////////////////////////////
 
@@ -81,7 +80,7 @@ func (h *Hashlocal) Processing(partial bool, IcapHeader textproto.MIMEHeader) (i
 	if isMal {
 		return h.handleMaliciousFile(fileSize)
 	}
-	return h.handleSuccessfulScan(file, fileSize, reqContentType)
+	return h.handleSuccessfulScan(StatusCodeStr, file, fileSize, reqContentType)
 }
 
 func (h *Hashlocal) initProcessing(IcapHeader textproto.MIMEHeader) {
@@ -197,17 +196,23 @@ func (h *Hashlocal) handleMaliciousFile(fileSize int) (int, interface{}, map[str
 	}
 }
 
-func (h *Hashlocal) handleSuccessfulScan(scannedFile []byte, fileSize int, reqContentType ContentTypes.ContentType) (int, interface{}, map[string]string, map[string]interface{}, map[string]interface{}, map[string]interface{}) {
+func (h *Hashlocal) handleSuccessfulScan(StatusCodeStr int, scannedFile []byte, fileSize int, reqContentType ContentTypes.ContentType) (int, interface{}, map[string]string, map[string]interface{}, map[string]interface{}, map[string]interface{}) {
 	// Log headers and processing stop
 	h.generalFunc.LogHTTPMsgHeaders(h.methodName)
-	logging.Logger.Info(utils.PrepareLogMsg(h.xICAPMetadata, h.serviceName+" service has stopped processing"))
+
 	h.msgHeadersAfterProcessing = h.generalFunc.LogHTTPMsgHeaders(h.methodName)
 
 	// Process the scanned file
 	scannedFile = h.generalFunc.PreparingFileAfterScanning(scannedFile, reqContentType, h.methodName)
+	logging.Logger.Info(utils.PrepareLogMsg(h.xICAPMetadata, h.serviceName+" service has stopped processing"))
 
-	return utils.NoModificationStatusCodeStr, h.generalFunc.ReturningHttpMessageWithFile(h.methodName, scannedFile),
+	// The file was processed successfully with no changes
+	if StatusCodeStr == 0 {
+		StatusCodeStr = utils.NoModificationStatusCodeStr
+	}
+	return StatusCodeStr, h.generalFunc.ReturningHttpMessageWithFile(h.methodName, scannedFile),
 		h.serviceHeaders, h.msgHeadersBeforeProcessing, h.msgHeadersAfterProcessing, h.vendorMsgs
+
 }
 
 func (h *Hashlocal) saveErrorPageBody(body []byte) {
@@ -270,7 +275,7 @@ func (h *Hashlocal) calculateFileHash(file []byte) (string, error) {
 func mapToString(m map[string]string) string {
 	var sb strings.Builder
 	for key, value := range m {
-		sb.WriteString(fmt.Sprintf("\r\n"))
+		sb.WriteString("\r\n")
 		sb.WriteString(fmt.Sprintf("%s: %s", key, value))
 	}
 	return sb.String()


### PR DESCRIPTION
Updated logic to detect and handle rejected extensions in the **hashlocal** and **clhashlookup** services.